### PR TITLE
Add PyPI Publishing Workflow and License to Project

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+    - name: Build and publish
+      env:
+        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        poetry build
+        poetry publish 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sukeesh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 

--- a/README.md
+++ b/README.md
@@ -12,31 +12,49 @@
 
 ## Installation
 
-1. **Clone the Repository**
+### Installation
 
-   ```bash
-   git clone https://github.com/sukeesh/gpush.git
-   cd gpush
-   ```
+#### Using Pipx (All Platforms)
+```bash
+# Install pipx if you haven't already
+python3 -m pip install --user pipx
+python3 -m pipx ensurepath
 
-2. **Install Poetry** (if you haven't already):
+# Install gpush
+pipx install gpush
+```
 
-   ```bash
-   curl -sSL https://install.python-poetry.org | python3 -
-   ```
+That's it! You can now use `gpush` from anywhere.
 
-3. **(Optional) Create and Activate a Virtual Environment Using pyenv**
+### Alternative Installation Methods
 
-   ```bash
-   pyenv virtualenv 3.11.9 gpush
-   pyenv activate gpush
-   ```
+#### Using Homebrew (macOS/Linux)
+```bash
+brew tap sukeesh/gpush
+brew install gpush
+```
 
-4. **Install Dependencies with Poetry**
+### Binary Installation
 
-   ```bash
-   poetry install
-   ```
+Download the latest binary for your platform from our [releases page](https://github.com/sukeesh/gpush/releases).
+
+#### Windows
+1. Download `gpush-windows-latest.exe`
+2. Rename to `gpush.exe`
+3. Move to a directory in your PATH
+
+#### macOS/Linux
+1. Download the appropriate binary
+2. Make it executable: `chmod +x gpush`
+3. Move to a directory in your PATH: `sudo mv gpush /usr/local/bin/`
+
+### Development Installation
+
+```bash
+git clone https://github.com/sukeesh/gpush.git
+cd gpush
+poetry install
+```
 
 ## Configuration
 

--- a/build.yml
+++ b/build.yml
@@ -1,0 +1,40 @@
+name: Build Binaries
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller poetry
+        poetry install
+        
+    - name: Build binary
+      run: |
+        pyinstaller --onefile --name gpush src/gpush/cli.py
+        
+    - name: Upload binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./dist/gpush${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+        asset_name: gpush-${{ matrix.os }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+        asset_content_type: application/octet-stream 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,24 @@
 name = "gpush"
 version = "0.1.0"
 description = "Automated GitHub PR creation tool"
-authors = ["Your Name <your.email@example.com>"]
+authors = ["Sukeesh <vsukeeshbabu@gmail.com>"]
 readme = "README.md"
+homepage = "https://github.com/sukeesh/gpush"
+repository = "https://github.com/sukeesh/gpush"
+keywords = ["github", "pull-request", "automation", "cli"]
+license = "MIT"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Version Control :: Git",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
+]
 packages = [{include = "gpush", from = "src"}]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for automatically publishing the project to PyPI upon a new release. Additionally, it includes the MIT License for the project and updates the README to reflect new installation methods.

### Changes Made:
- **GitHub Actions Workflow**: 
  - Added a new file `.github/workflows/publish.yml` that defines a workflow to publish the package to PyPI when a release is created.
  - The workflow sets up Python 3.11, installs Poetry, and uses it to build and publish the package, utilizing a secret token for authentication.

- **License**: 
  - Added a new `LICENSE` file containing the MIT License to clarify the terms of use for the project.

- **README Updates**: 
  - Revised the installation instructions to include:
    - Installation via `pipx` for all platforms.
    - An alternative installation method using Homebrew for macOS/Linux.
  - Improved clarity and organization of the installation section.

### Benefits:
- This workflow automates the publishing process, reducing manual steps and potential errors.
- Including a license enhances the project's professionalism and informs users of their rights.
- Updated README ensures users have clear and accessible installation options.

Please review the changes and let me know if you have any questions or need further modifications!